### PR TITLE
Add run action

### DIFF
--- a/.github/workflows/branch_deployments.yml
+++ b/.github/workflows/branch_deployments.yml
@@ -94,5 +94,6 @@ jobs:
           deployment: ${{ steps.deploy.outputs.deployment }}
           repository: repo
           job: all_cereals_job
+          tags_json: "{\"foo\": \"bar\"}"
         env:
           DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}

--- a/.github/workflows/branch_deployments.yml
+++ b/.github/workflows/branch_deployments.yml
@@ -86,3 +86,11 @@ jobs:
           location: ${{ toJson(matrix.location) }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Launch a run
+        uses: ./run
+        with:
+          location: ${{ toJson(matrix.location) }}
+          deployment: ${{ steps.deploy.outputs.deployment }}
+          repository: repo
+          job: all_cereals_job

--- a/.github/workflows/branch_deployments.yml
+++ b/.github/workflows/branch_deployments.yml
@@ -94,3 +94,5 @@ jobs:
           deployment: ${{ steps.deploy.outputs.deployment }}
           repository: repo
           job: all_cereals_job
+        env:
+          DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -27,7 +27,7 @@ outputs:
     description: 'The Cloud deployment associated with this branch.'
 runs:
   using: 'docker'
-  image: 'docker://public.ecr.aws/a6x1l7i5/gh-action-test:0.28'
+  image: 'docker://public.ecr.aws/a6x1l7i5/gh-action-test:0.29'
   # image: '../src/Dockerfile'
   entrypoint: '/deploy.sh'
   args:

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -27,7 +27,7 @@ outputs:
     description: 'The Cloud deployment associated with this branch.'
 runs:
   using: 'docker'
-  image: 'docker://public.ecr.aws/a6x1l7i5/gh-action-test:0.23'
+  image: 'docker://public.ecr.aws/a6x1l7i5/gh-action-test:0.28'
   # image: '../src/Dockerfile'
   entrypoint: '/deploy.sh'
   args:

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -27,7 +27,7 @@ outputs:
     description: 'The Cloud deployment associated with this branch.'
 runs:
   using: 'docker'
-  image: 'docker://public.ecr.aws/a6x1l7i5/gh-action-test:0.29'
+  image: 'docker://public.ecr.aws/a6x1l7i5/gh-action-test:0.30'
   # image: '../src/Dockerfile'
   entrypoint: '/deploy.sh'
   args:

--- a/notify/action.yml
+++ b/notify/action.yml
@@ -25,7 +25,7 @@ inputs:
     description: 'Alternative to providing organization ID. The URL of your Dagster Cloud organization.'
 runs:
   using: 'docker'
-  image: 'docker://public.ecr.aws/a6x1l7i5/gh-action-test:0.29'
+  image: 'docker://public.ecr.aws/a6x1l7i5/gh-action-test:0.30'
   # image: '../src/Dockerfile'
   entrypoint: '/notify.sh'
   args:

--- a/notify/action.yml
+++ b/notify/action.yml
@@ -25,7 +25,7 @@ inputs:
     description: 'Alternative to providing organization ID. The URL of your Dagster Cloud organization.'
 runs:
   using: 'docker'
-  image: 'docker://public.ecr.aws/a6x1l7i5/gh-action-test:0.28'
+  image: 'docker://public.ecr.aws/a6x1l7i5/gh-action-test:0.29'
   # image: '../src/Dockerfile'
   entrypoint: '/notify.sh'
   args:

--- a/notify/action.yml
+++ b/notify/action.yml
@@ -25,7 +25,7 @@ inputs:
     description: 'Alternative to providing organization ID. The URL of your Dagster Cloud organization.'
 runs:
   using: 'docker'
-  image: 'docker://public.ecr.aws/a6x1l7i5/gh-action-test:0.23'
+  image: 'docker://public.ecr.aws/a6x1l7i5/gh-action-test:0.28'
   # image: '../src/Dockerfile'
   entrypoint: '/notify.sh'
   args:

--- a/run/action.yml
+++ b/run/action.yml
@@ -18,13 +18,18 @@ inputs:
     description: 'The job to run.'
   tags_json:
     required: false
-    description: 'The job to run.'
+    description: 'A JSON dict of tags to apply to the run, input as a string.'
+    default: "{}"
+  config_json:
+    required: false
+    description: 'A JSON dict of config to apply to the run, input as a string.'
+    default: "{}"
   dagster_cloud_url:
     required: false
     description: 'Alternative to providing organization ID. The URL of your Dagster Cloud organization.'
 runs:
   using: 'docker'
-  image: 'docker://public.ecr.aws/a6x1l7i5/gh-action-test:0.28'
+  image: 'docker://public.ecr.aws/a6x1l7i5/gh-action-test:0.29'
   # image: '../src/Dockerfile'
   entrypoint: '/run.sh'
   args:

--- a/run/action.yml
+++ b/run/action.yml
@@ -1,5 +1,7 @@
-name: 'Update PR Message'
-description: 'Updates the Dagster Cloud build message on a Pull Request.'
+name: 'Launch run'
+description: |
+  Launches a run of the specified job on the provided deployment. Can be used to
+  run smoketests or test setup on a branch deployment.
 inputs:
   organization_id:
     required: false
@@ -9,7 +11,7 @@ inputs:
     description: 'The deployment to run a job on.'
   location:
     required: true
-    description: 'The code location to deploy.'
+    description: 'The code location in which the job repo lives.'
   repository:
     required: false
     description: 'The repository in which the job lives.'
@@ -27,9 +29,12 @@ inputs:
   dagster_cloud_url:
     required: false
     description: 'Alternative to providing organization ID. The URL of your Dagster Cloud organization.'
+outputs:
+  run_id:
+    description: 'The ID of the launched run.'
 runs:
   using: 'docker'
-  image: 'docker://public.ecr.aws/a6x1l7i5/gh-action-test:0.29'
+  image: 'docker://public.ecr.aws/a6x1l7i5/gh-action-test:0.30'
   # image: '../src/Dockerfile'
   entrypoint: '/run.sh'
   args:

--- a/run/action.yml
+++ b/run/action.yml
@@ -16,12 +16,15 @@ inputs:
   job:
     required: false
     description: 'The job to run.'
+  tags_json:
+    required: false
+    description: 'The job to run.'
   dagster_cloud_url:
     required: false
     description: 'Alternative to providing organization ID. The URL of your Dagster Cloud organization.'
 runs:
   using: 'docker'
-  image: 'docker://public.ecr.aws/a6x1l7i5/gh-action-test:0.26'
+  image: 'docker://public.ecr.aws/a6x1l7i5/gh-action-test:0.27'
   # image: '../src/Dockerfile'
   entrypoint: '/run.sh'
   args:

--- a/run/action.yml
+++ b/run/action.yml
@@ -1,0 +1,28 @@
+name: 'Update PR Message'
+description: 'Updates the Dagster Cloud build message on a Pull Request.'
+inputs:
+  organization_id:
+    required: false
+    description: 'The organization ID of your Dagster Cloud organization.'
+  deployment:
+    required: false
+    description: 'The deployment to run a job on.'
+  location:
+    required: true
+    description: 'The code location to deploy.'
+  repostiory:
+    required: false
+    description: 'The repository in which the job lives.'
+  job:
+    required: false
+    description: 'The job to run.'
+  dagster_cloud_url:
+    required: false
+    description: 'Alternative to providing organization ID. The URL of your Dagster Cloud organization.'
+runs:
+  using: 'docker'
+  image: 'docker://public.ecr.aws/a6x1l7i5/gh-action-test:0.24'
+  # image: '../src/Dockerfile'
+  entrypoint: '/run.sh'
+  args:
+    - ${{ inputs.pr }}

--- a/run/action.yml
+++ b/run/action.yml
@@ -24,7 +24,7 @@ inputs:
     description: 'Alternative to providing organization ID. The URL of your Dagster Cloud organization.'
 runs:
   using: 'docker'
-  image: 'docker://public.ecr.aws/a6x1l7i5/gh-action-test:0.27'
+  image: 'docker://public.ecr.aws/a6x1l7i5/gh-action-test:0.28'
   # image: '../src/Dockerfile'
   entrypoint: '/run.sh'
   args:

--- a/run/action.yml
+++ b/run/action.yml
@@ -10,7 +10,7 @@ inputs:
   location:
     required: true
     description: 'The code location to deploy.'
-  repostiory:
+  repository:
     required: false
     description: 'The repository in which the job lives.'
   job:
@@ -21,7 +21,7 @@ inputs:
     description: 'Alternative to providing organization ID. The URL of your Dagster Cloud organization.'
 runs:
   using: 'docker'
-  image: 'docker://public.ecr.aws/a6x1l7i5/gh-action-test:0.24'
+  image: 'docker://public.ecr.aws/a6x1l7i5/gh-action-test:0.25'
   # image: '../src/Dockerfile'
   entrypoint: '/run.sh'
   args:

--- a/run/action.yml
+++ b/run/action.yml
@@ -21,7 +21,7 @@ inputs:
     description: 'Alternative to providing organization ID. The URL of your Dagster Cloud organization.'
 runs:
   using: 'docker'
-  image: 'docker://public.ecr.aws/a6x1l7i5/gh-action-test:0.25'
+  image: 'docker://public.ecr.aws/a6x1l7i5/gh-action-test:0.26'
   # image: '../src/Dockerfile'
   entrypoint: '/run.sh'
   args:

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -15,3 +15,4 @@ COPY fetch_github_avatar.py /fetch_github_avatar.py
 
 COPY notify.sh /notify.sh
 COPY deploy.sh /deploy.sh
+COPY run.sh /run.sh

--- a/src/run.sh
+++ b/src/run.sh
@@ -23,5 +23,5 @@ dagster-cloud job launch \
     --location "${LOCATION_NAME}" \
     --repository "${INPUT_REPOSITORY}" \
     --job "${INPUT_JOB}"
-    # --tags "${INPUT_TAGS_JSON}"
+    --tags "${INPUT_TAGS_JSON}"
     # --config-json "${INPUT_CONFIG_JSON}"

--- a/src/run.sh
+++ b/src/run.sh
@@ -22,6 +22,6 @@ dagster-cloud job launch \
     --api-token "$DAGSTER_CLOUD_API_TOKEN" \
     --location "${LOCATION_NAME}" \
     --repository "${INPUT_REPOSITORY}" \
-    --job "${INPUT_JOB}"
+    --job "${INPUT_JOB}" \
     --tags "${INPUT_TAGS_JSON}"
     # --config-json "${INPUT_CONFIG_JSON}"

--- a/src/run.sh
+++ b/src/run.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -
+
+# Load JSON-encoded location info into env vars
+# This produces the env vars
+# LOCATION_NAME, LOCATION_LOCATION_FILE, LOCATION_REGISTRY
+source $(python /expand_json_env.py)
+
+if [ -z $LOCATION_REGISTRY ]; then
+    LOCATION_REGISTRY="${!LOCATION_REGISTRY_ENV}"
+fi
+
+if [ -z $DAGSTER_CLOUD_URL ]; then
+    if [ -z $INPUT_DAGSTER_CLOUD_URL ]; then
+        export DAGSTER_CLOUD_URL="https://dagster.cloud/${INPUT_ORGANIZATION_ID}"
+    else
+        export DAGSTER_CLOUD_URL="${INPUT_DAGSTER_CLOUD_URL}"
+    fi
+fi
+
+dagster-cloud job launch \
+    --url "${DAGSTER_CLOUD_URL}/${INPUT_DEPLOYMENT}" \
+    --api-token "$DAGSTER_CLOUD_API_TOKEN" \
+    --location "${LOCATION_NAME}" \
+    --repostiory "${INPUT_REPOSITORY}"
+    --job "${INPUT_JOB}"
+    # --tags "${INPUT_TAGS_JSON}"
+    # --config-json "${INPUT_CONFIG_JSON}"

--- a/src/run.sh
+++ b/src/run.sh
@@ -21,7 +21,7 @@ dagster-cloud job launch \
     --url "${DAGSTER_CLOUD_URL}/${INPUT_DEPLOYMENT}" \
     --api-token "$DAGSTER_CLOUD_API_TOKEN" \
     --location "${LOCATION_NAME}" \
-    --repostiory "${INPUT_REPOSITORY}"
+    --repository "${INPUT_REPOSITORY}"
     --job "${INPUT_JOB}"
     # --tags "${INPUT_TAGS_JSON}"
     # --config-json "${INPUT_CONFIG_JSON}"

--- a/src/run.sh
+++ b/src/run.sh
@@ -21,7 +21,7 @@ dagster-cloud job launch \
     --url "${DAGSTER_CLOUD_URL}/${INPUT_DEPLOYMENT}" \
     --api-token "$DAGSTER_CLOUD_API_TOKEN" \
     --location "${LOCATION_NAME}" \
-    --repository "${INPUT_REPOSITORY}"
+    --repository "${INPUT_REPOSITORY}" \
     --job "${INPUT_JOB}"
     # --tags "${INPUT_TAGS_JSON}"
     # --config-json "${INPUT_CONFIG_JSON}"

--- a/src/run.sh
+++ b/src/run.sh
@@ -23,5 +23,5 @@ dagster-cloud job launch \
     --location "${LOCATION_NAME}" \
     --repository "${INPUT_REPOSITORY}" \
     --job "${INPUT_JOB}" \
-    --tags "${INPUT_TAGS_JSON}"
-    # --config-json "${INPUT_CONFIG_JSON}"
+    --tags "${INPUT_TAGS_JSON}" \
+    --config-json "${INPUT_CONFIG_JSON}"

--- a/src/run.sh
+++ b/src/run.sh
@@ -17,7 +17,8 @@ if [ -z $DAGSTER_CLOUD_URL ]; then
     fi
 fi
 
-dagster-cloud job launch \
+RUN_ID=$(
+    dagster-cloud job launch \
     --url "${DAGSTER_CLOUD_URL}/${INPUT_DEPLOYMENT}" \
     --api-token "$DAGSTER_CLOUD_API_TOKEN" \
     --location "${LOCATION_NAME}" \
@@ -25,3 +26,6 @@ dagster-cloud job launch \
     --job "${INPUT_JOB}" \
     --tags "${INPUT_TAGS_JSON}" \
     --config-json "${INPUT_CONFIG_JSON}"
+)
+
+echo "::set-output name=run_id::${RUN_ID}"


### PR DESCRIPTION
Adds a GitHub action which can be used to queue a run on a deployment, including a Branch Deployment created in the same workflow.

This can be used for smoketesting or regenerating an asset on a branch.

Required inputs are `location`, `repository`, and `job`, can optionally provide `tags_json` and `config_json` to configure the run.