### PR TITLE
Increase timeouts to 6m, 60s for agent heartbeat

### DIFF
--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -39,7 +39,7 @@ outputs:
     description: 'The Cloud deployment associated with this branch.'
 runs:
   using: 'docker'
-  image: 'docker://dagster/branch-deployments-action:v0.2.2'
+  image: 'docker://dagster/branch-deployments-action:v0.2.3'
   # image: '../src/Dockerfile'
   entrypoint: '/deploy.sh'
   args:

--- a/notify/action.yml
+++ b/notify/action.yml
@@ -30,7 +30,7 @@ inputs:
 
 runs:
   using: 'docker'
-  image: 'docker://dagster/branch-deployments-action:v0.2.2'
+  image: 'docker://dagster/branch-deployments-action:v0.2.3'
   # image: '../src/Dockerfile'
   entrypoint: '/notify.sh'
   args:

--- a/run/action.yml
+++ b/run/action.yml
@@ -39,7 +39,7 @@ outputs:
     description: 'The ID of the launched run.'
 runs:
   using: 'docker'
-  image: 'docker://dagster/branch-deployments-action:v0.2.2'
+  image: 'docker://dagster/branch-deployments-action:v0.2.3'
   # image: '../src/Dockerfile'
   entrypoint: '/run.sh'
   args:

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,10 +1,4 @@
-FROM python:3.8.12-slim
-
-# Install deps
-RUN apt update && apt install git -y
-RUN pip install dagster \
-                dagster-cloud-cli \ 
-                PyGithub
+FROM clithing
 
 # Copy over various Python utilities
 COPY create_or_update_comment.py /create_or_update_comment.py

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -95,4 +95,7 @@ dagster-cloud workspace add-location \
     --api-token "$DAGSTER_CLOUD_API_TOKEN" \
     --location-file "${INPUT_LOCATION_FILE}" \
     --location-name "${INPUT_LOCATION_NAME}" \
-    --image "${INPUT_REGISTRY}:${INPUT_IMAGE_TAG}"
+    --image "${INPUT_REGISTRY}:${INPUT_IMAGE_TAG}" \
+    --location-load-timeout 360 \
+    --agent-heartbeat-timeout 90
+

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -96,6 +96,6 @@ dagster-cloud workspace add-location \
     --location-file "${INPUT_LOCATION_FILE}" \
     --location-name "${INPUT_LOCATION_NAME}" \
     --image "${INPUT_REGISTRY}:${INPUT_IMAGE_TAG}" \
-    --location-load-timeout 360 \
+    --location-load-timeout 600 \
     --agent-heartbeat-timeout 90
 


### PR DESCRIPTION
## Summary

Increases location load timeout to 6 minutes instead of 5, and the agent spinup timeout to 90 seconds.