### PR TITLE
Add formatted error message, link if workspace deploy fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pass the deployment to the `deploy` action directly.
 
 ```yaml
 - name: Deploy to Production
-  uses: dagster-io/cloud-branch-deployments-action/deploy@v0.2.2
+  uses: dagster-io/cloud-branch-deployments-action/deploy@v0.2.4
   id: deploy
   with:
     organization_id: pied-piper
@@ -38,7 +38,7 @@ instead pass information about the PR itself.
 
 ```yaml
 - name: Deploy to Branch Deployment
-  uses: dagster-io/cloud-branch-deployments-action/deploy@v0.2.2
+  uses: dagster-io/cloud-branch-deployments-action/deploy@v0.2.4
   id: deploy
   with:
     organization_id: pied-piper

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -39,7 +39,7 @@ outputs:
     description: 'The Cloud deployment associated with this branch.'
 runs:
   using: 'docker'
-  image: 'docker://dagster/branch-deployments-action:v0.2.3'
+  image: 'docker://dagster/branch-deployments-action:v0.2.4'
   # image: '../src/Dockerfile'
   entrypoint: '/deploy.sh'
   args:

--- a/notify/action.yml
+++ b/notify/action.yml
@@ -30,7 +30,7 @@ inputs:
 
 runs:
   using: 'docker'
-  image: 'docker://dagster/branch-deployments-action:v0.2.3'
+  image: 'docker://dagster/branch-deployments-action:v0.2.4'
   # image: '../src/Dockerfile'
   entrypoint: '/notify.sh'
   args:

--- a/run/action.yml
+++ b/run/action.yml
@@ -39,7 +39,7 @@ outputs:
     description: 'The ID of the launched run.'
 runs:
   using: 'docker'
-  image: 'docker://dagster/branch-deployments-action:v0.2.3'
+  image: 'docker://dagster/branch-deployments-action:v0.2.4'
   # image: '../src/Dockerfile'
   entrypoint: '/run.sh'
   args:

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -82,7 +82,7 @@ fi
 
 
 if [ -z $DEPLOYMENT_NAME ]; then
-    echo "Failed to update branch deployment"
+    echo "::error title=Failed to update branch deployment::Failed to update branch deployment"
     exit 1
 fi
 
@@ -99,3 +99,7 @@ dagster-cloud workspace add-location \
     --location-load-timeout 600 \
     --agent-heartbeat-timeout 90
 
+if [ $? -ne 0 ]; then
+  echo "::error title=Deploy failed::Deploy failed. To view status of your code locations, visit ${DAGSTER_CLOUD_URL}/${DEPLOYMENT_NAME}/workspace"
+  exit 1
+fi


### PR DESCRIPTION
Adds a formatted error message with a link to the workspace page if a workspace deploy fails.

For an example, see https://github.com/dagster-io/cloud-branch-deployments-action/actions/runs/2799787110/attempts/4